### PR TITLE
Fix support for Zulu arm64 architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Currently, the following distributions are supported:
 
 **NOTE:** Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from `adopt` to `temurin` to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).
 
+**NOTE:** For Zulu OpenJDK architectures x64 and arm64 are mapped to x86 / arm with proper hw_bitness.
+
 ### Caching packages dependencies
 The action has a built-in functionality for caching and restoring dependencies. It uses [actions/cache](https://github.com/actions/cache) under hood for caching dependencies but requires less configuration settings. Supported package managers are gradle, maven and sbt. The format of the used cache key is `setup-java-${{ platform }}-${{ packageManager }}-${{ fileHash }}`, where the hash is based on the following files:
 - gradle: `**/*.gradle*`, `**/gradle-wrapper.properties`

--- a/__tests__/distributors/zulu-installer.test.ts
+++ b/__tests__/distributors/zulu-installer.test.ts
@@ -52,6 +52,14 @@ describe('getAvailableVersions', () => {
     [
       { version: '8', architecture: 'x64', packageType: 'jre+fx', checkLatest: false },
       '?os=macos&ext=tar.gz&bundle_type=jre&javafx=true&arch=x86&hw_bitness=64&release_status=ga&features=fx'
+    ],
+    [
+      { version: '11', architecture: 'arm64', packageType: 'jdk', checkLatest: false },
+      '?os=macos&ext=tar.gz&bundle_type=jdk&javafx=false&arch=arm&hw_bitness=64&release_status=ga'
+    ],
+    [
+      { version: '11', architecture: 'arm', packageType: 'jdk', checkLatest: false },
+      '?os=macos&ext=tar.gz&bundle_type=jdk&javafx=false&arch=arm&hw_bitness=&release_status=ga'
     ]
   ])('build correct url for %s -> %s', async (input, parsedUrl) => {
     const distribution = new ZuluDistribution(input);

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -102070,6 +102070,9 @@ class ZuluDistribution extends base_installer_1.JavaBase {
         else if (this.architecture == 'x86') {
             return { arch: 'x86', hw_bitness: '32', abi: '' };
         }
+        else if (this.architecture == 'arm64') {
+            return { arch: 'arm', hw_bitness: '64', abi: '' };
+        }
         else {
             return { arch: this.architecture, hw_bitness: '', abi: '' };
         }

--- a/src/distributions/zulu/installer.ts
+++ b/src/distributions/zulu/installer.ts
@@ -133,6 +133,8 @@ export class ZuluDistribution extends JavaBase {
       return { arch: 'x86', hw_bitness: '64', abi: '' };
     } else if (this.architecture == 'x86') {
       return { arch: 'x86', hw_bitness: '32', abi: '' };
+    } else if (this.architecture == 'arm64') {
+      return { arch: 'arm', hw_bitness: '64', abi: '' };
     } else {
       return { arch: this.architecture, hw_bitness: '', abi: '' };
     }


### PR DESCRIPTION


**Description:**
Azul API stopped to support arm64 architecture, the only supported
option for ARM cpus is now 'arm'. This requires to set up hw_bitness
properly to get 64 bits version. 32 bits version can be obtained by
using 'arm' as an architecture.

**Check list:**
- [X] Mark if documentation changes are required.
- [X] Mark if tests were added or updated to cover the changes.